### PR TITLE
Use forked version of `parity-wasm`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lto = "fat"
 codegen-units = 1
 
 [dependencies]
-parity-wasm = { version = "0.45", default-features = false }
+parity-wasm = { package = "linera-parity-wasm", version = "0.45.1-linera.1", default-features = false }
 
 [dev-dependencies]
 binaryen = "0.12"


### PR DESCRIPTION
# Motivation

The `parity-wasm` crate is now deprecated, which makes it difficult to upstream bug fixes. One required bug fix is for how the `call_indirect` opcode handles table indices. With the archived version of the crate, it only supports table index zero hard-coded as a single byte. Newer versions of LLVM (and therefore newer versions of Rust) compile to Wasm representing the table index using more than one byte. This causes instrumentation of those binaries to fail with an error message "Invalid table reference".

# Proposal

Use a forked version of `parity-wasm` which Includes a fix for `call_indirect` opcode's usage of table indices.