### PR TITLE
Rename crate to `linera-wasm-instrument`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasm-instrument"
+name = "linera-wasm-instrument"
 version = "0.4.0-linera.1"
 edition = "2021"
 rust-version = "1.56.1"


### PR DESCRIPTION
Avoid conflict with the upstream crate.